### PR TITLE
CompanyのUPDATE処理のテスト実装

### DIFF
--- a/src/main/java/com/abeck/ssfa/service/CompanyServiceImpl.java
+++ b/src/main/java/com/abeck/ssfa/service/CompanyServiceImpl.java
@@ -23,7 +23,7 @@ public class CompanyServiceImpl implements CompanyService {
 
     @Override
     public CompanyEntity findCompanyById(int companyId) {
-        return companyMapper.findCompanyById(companyId).orElseThrow(() -> new CompanyNotFoundException("Company Not Found"));
+        return companyMapper.findCompanyById(companyId).orElseThrow(() -> new CompanyNotFoundException("未登録の企業です。"));
     }
 
     @Override

--- a/src/test/java/com/abeck/ssfa/mapper/CompanyMapperTest.java
+++ b/src/test/java/com/abeck/ssfa/mapper/CompanyMapperTest.java
@@ -93,4 +93,12 @@ public class CompanyMapperTest {
         CompanyEntity companyEntity = new CompanyEntity(0, "未登録株式会社", "0312345678", "神奈川県", "川崎市", "高津区1-1-1" ,"S", 1);
         companyMapper.insertCompany(companyEntity);
     }
+
+    @Test
+    @DataSet(value = "datasets/companies.yml")
+    @Transactional
+    void 企業更新で指定したIDの企業情報が更新できること() {
+        CompanyEntity companyEntity = new CompanyEntity(1, "未登録株式会社", "0312345678", "神奈川県", "川崎市", "高津区1-1-1" ,"S", 1);
+        companyMapper.updateCompany(1, companyEntity);
+    }
 }

--- a/src/test/java/com/abeck/ssfa/service/CompanyServiceImplTest.java
+++ b/src/test/java/com/abeck/ssfa/service/CompanyServiceImplTest.java
@@ -100,10 +100,11 @@ class CompanyServiceImplTest {
     }
 
     @Test
-    public void 企業で存在しないIDを指定したときに例外がスローされること() {
+    public void 企業更新で存在しないIDを指定したときに例外がスローされること() {
         CompanyEntity entity = new CompanyEntity(1, "株式会社ABECK","0312345678","東京都","千代田区","1-1-1","S",1);
         doReturn(Optional.empty()).when(companyMapper).findCompanyById(99);
-        assertThatThrownBy(() -> companyServiceImpl.updateCompany(99, entity)).isInstanceOfSatisfying(CompanyNotFoundException.class, e -> assertThat(e.getMessage()).isEqualTo("未登録の企業です。"));
+        assertThatThrownBy(() -> companyServiceImpl.updateCompany(99, entity))
+                .isInstanceOfSatisfying(CompanyNotFoundException.class, e -> assertThat(e.getMessage()).isEqualTo("未登録の企業です。"));
         verify(companyMapper, times(1)). findCompanyById(99);
         verify(companyMapper, times(0)).findCompanyByNameAndPhone("株式会社ABECK","0312345678");
         verify(companyMapper, times(0)).updateCompany(99,entity);
@@ -114,9 +115,12 @@ class CompanyServiceImplTest {
         CompanyEntity entity = new CompanyEntity(1, "株式会社ABECK","0312345678","東京都","千代田区","1-1-1","S",1);
         doReturn(Optional.of(new CompanyEntity(1, "株式会社ABECK","0312345678","東京都","千代田区","1-1-1","S",1)))
                 .when(companyMapper).findCompanyByNameAndPhone("株式会社ABECK","0312345678");
+        doReturn(Optional.of(new CompanyEntity(1, "株式会社ABECK","0312345678","東京都","千代田区","1-1-1","S",1)))
+                .when(companyMapper).findCompanyById(1);
 
-        assertThatThrownBy(() -> companyServiceImpl.createCompany("株式会社ABECK","0312345678","東京都","千代田区","1-1-1","S",1))
+        assertThatThrownBy(() -> companyServiceImpl.updateCompany(1, entity))
                 .isInstanceOfSatisfying(CompanyNotUniqueException.class, e -> assertThat(e.getMessage()).isEqualTo("すでに登録されている企業です。"));
+        verify(companyMapper, times(1)). findCompanyById(1);
         verify(companyMapper, times(1)).findCompanyByNameAndPhone("株式会社ABECK","0312345678");
         verify(companyMapper, times(0)).updateCompany(1,entity);
     }

--- a/src/test/java/com/abeck/ssfa/service/CompanyServiceImplTest.java
+++ b/src/test/java/com/abeck/ssfa/service/CompanyServiceImplTest.java
@@ -43,7 +43,8 @@ class CompanyServiceImplTest {
 
     @Test
     public void 企業検索で存在するIDを指定したときに正常に企業情報が返されること() throws CompanyNotFoundException {
-        doReturn(Optional.of(new CompanyEntity(1,"株式会社ABECK","0312345678","東京都","千代田区","1-1-1","S",1))).when(companyMapper).findCompanyById(1);
+        doReturn(Optional.of(new CompanyEntity(1,"株式会社ABECK","0312345678","東京都","千代田区","1-1-1","S",1)))
+                .when(companyMapper).findCompanyById(1);
 
         CompanyEntity actual = companyServiceImpl.findCompanyById(1);
         assertThat(actual).isEqualTo(new CompanyEntity(1,"株式会社ABECK","0312345678","東京都","千代田区","1-1-1","S",1));
@@ -54,7 +55,8 @@ class CompanyServiceImplTest {
     public void 企業検索で存在しないIDを指定したときに例外がスローされること() {
         doReturn(Optional.empty()).when(companyMapper).findCompanyById(99);
 
-        assertThatThrownBy(() -> companyServiceImpl.findCompanyById(99)).isInstanceOfSatisfying(CompanyNotFoundException.class, e -> assertThat(e.getMessage()).isEqualTo("Company Not Found"));
+        assertThatThrownBy(() -> companyServiceImpl.findCompanyById(99))
+                .isInstanceOfSatisfying(CompanyNotFoundException.class, e -> assertThat(e.getMessage()).isEqualTo("未登録の企業です。"));
         verify(companyMapper, times(1)).findCompanyById(99);
     }
 
@@ -74,10 +76,48 @@ class CompanyServiceImplTest {
     public void 企業登録で企業名と電話番号の組み合わせが存在する企業を登録したときに例外がスローされること() {
         CompanyEntity entity = new CompanyEntity(0, "株式会社ABECK","0312345678","東京都","千代田区","1-1-1","S",1);
         CompanyEntity expectedCompany = new CompanyEntity(0,"株式会社ABECK","0312345678","東京都","千代田区","1-1-1","S",1);
-        doReturn(Optional.of(new CompanyEntity(0, "株式会社ABECK","0312345678","東京都","千代田区","1-1-1","S",1))).when(companyMapper).findCompanyByNameAndPhone("株式会社ABECK","0312345678");
+        doReturn(Optional.of(new CompanyEntity(0, "株式会社ABECK","0312345678","東京都","千代田区","1-1-1","S",1)))
+                .when(companyMapper).findCompanyByNameAndPhone("株式会社ABECK","0312345678");
 
-        assertThatThrownBy(() -> companyServiceImpl.createCompany("株式会社ABECK","0312345678","東京都","千代田区","1-1-1","S",1)).isInstanceOfSatisfying(CompanyNotUniqueException.class, e -> assertThat(e.getMessage()).isEqualTo("すでに登録されている企業です。"));
+        assertThatThrownBy(() -> companyServiceImpl.createCompany("株式会社ABECK","0312345678","東京都","千代田区","1-1-1","S",1))
+                .isInstanceOfSatisfying(CompanyNotUniqueException.class, e -> assertThat(e.getMessage()).isEqualTo("すでに登録されている企業です。"));
         verify(companyMapper, times(1)).findCompanyByNameAndPhone("株式会社ABECK","0312345678");
         verify(companyMapper, times(0)).insertCompany(entity);
+    }
+
+    @Test
+    public void 企業が更新できること() {
+        CompanyEntity entity = new CompanyEntity(1, "株式会社ABECK","0312345678","東京都","千代田区","1-1-1","S",1);
+        doReturn(Optional.of(new CompanyEntity(1, "株式会社ABECK","0312345678","東京都","千代田区","1-1-1","S",1)))
+                .when(companyMapper).findCompanyById(1);
+        doReturn(Optional.empty()).when(companyMapper).findCompanyByNameAndPhone("株式会社ABECK","0312345678");
+        doNothing().when(companyMapper).updateCompany(1,entity);
+
+        companyServiceImpl.updateCompany(1,entity);
+        verify(companyMapper, times(1)). findCompanyById(1);
+        verify(companyMapper, times(1)).findCompanyByNameAndPhone("株式会社ABECK","0312345678");
+        verify(companyMapper, times(1)).updateCompany(1, entity);
+    }
+
+    @Test
+    public void 企業で存在しないIDを指定したときに例外がスローされること() {
+        CompanyEntity entity = new CompanyEntity(1, "株式会社ABECK","0312345678","東京都","千代田区","1-1-1","S",1);
+        doReturn(Optional.empty()).when(companyMapper).findCompanyById(99);
+        assertThatThrownBy(() -> companyServiceImpl.updateCompany(99, entity)).isInstanceOfSatisfying(CompanyNotFoundException.class, e -> assertThat(e.getMessage()).isEqualTo("未登録の企業です。"));
+        verify(companyMapper, times(1)). findCompanyById(99);
+        verify(companyMapper, times(0)).findCompanyByNameAndPhone("株式会社ABECK","0312345678");
+        verify(companyMapper, times(0)).updateCompany(99,entity);
+    }
+
+    @Test
+    public void 企業更新で企業名と電話番号の組み合わせが存在する企業を更新したときに例外がスローされること() {
+        CompanyEntity entity = new CompanyEntity(1, "株式会社ABECK","0312345678","東京都","千代田区","1-1-1","S",1);
+        doReturn(Optional.of(new CompanyEntity(1, "株式会社ABECK","0312345678","東京都","千代田区","1-1-1","S",1)))
+                .when(companyMapper).findCompanyByNameAndPhone("株式会社ABECK","0312345678");
+
+        assertThatThrownBy(() -> companyServiceImpl.createCompany("株式会社ABECK","0312345678","東京都","千代田区","1-1-1","S",1))
+                .isInstanceOfSatisfying(CompanyNotUniqueException.class, e -> assertThat(e.getMessage()).isEqualTo("すでに登録されている企業です。"));
+        verify(companyMapper, times(1)).findCompanyByNameAndPhone("株式会社ABECK","0312345678");
+        verify(companyMapper, times(0)).updateCompany(1,entity);
     }
 }

--- a/src/test/java/integrationtest/CompanyRestApiIntegrationTest.java
+++ b/src/test/java/integrationtest/CompanyRestApiIntegrationTest.java
@@ -1016,7 +1016,7 @@ public class CompanyRestApiIntegrationTest {
     @Test
     @DataSet(value = "datasets/companies.yml")
     @Transactional
-    void 企業登録で企業名と電話番号の組み合わせが存在する企業を登録したときにバリデーションエラーとなること() throws Exception {
+    void 企業登録で企業名と電話番号の組み合わせが存在する企業を登録したときに409エラーとなること() throws Exception {
         String response = mockMvc.perform(MockMvcRequestBuilders.post("/companies")
                         .contentType(MediaType.APPLICATION_JSON_VALUE)
                         .content("""
@@ -1082,7 +1082,7 @@ public class CompanyRestApiIntegrationTest {
     @Test
     @DataSet(value = "datasets/companies.yml")
     @Transactional
-    void 企業更新で企業名と電話番号の組み合わせが存在する企業を更新したときにバリデーションエラーとなること() throws Exception {
+    void 企業更新で企業名と電話番号の組み合わせが存在する企業を更新したときに409エラーとなること() throws Exception {
         String response = mockMvc.perform(MockMvcRequestBuilders.patch("/companies/1")
                         .contentType(MediaType.APPLICATION_JSON_VALUE)
                         .content("""

--- a/src/test/java/integrationtest/CompanyRestApiIntegrationTest.java
+++ b/src/test/java/integrationtest/CompanyRestApiIntegrationTest.java
@@ -241,7 +241,7 @@ public class CompanyRestApiIntegrationTest {
               "timestamp": "%s",
               "status": "404",
               "error": "Not Found",
-              "message": "Company Not Found",
+              "message": "未登録の企業です。",
               "path": "/companies/99"
             }
         """, timeStamp), response, new CustomComparator(JSONCompareMode.STRICT, new Customization("timestamp", (o1, o2) -> true


### PR DESCRIPTION
## チケットURL
[チケット#3](https://github.com/ABECKCROW/s-sfa-api/issues/3)

## 対応内容
CompaniesテーブルへのUPDATE処理のテスト実装
 - 単体テスト(Service, Mapper)
 - 結合テスト

## 対応背景
新しい企業を更新する機能の品質を保証するため。

## 妥協点
特になし。

## やったこと
下記のテスト実装
* 更新処理の正常処理
* 存在しないIDを指定した時の例外処理
* 重複企業の更新時のバリデーションエラー

## やってないこと
特になし。

## レビュー観点
- より良い設計方法はないか？
- テスト漏れがないか？

## 補足
下記、CIによる自動テスト結果です。
https://github.com/ABECKCROW/s-sfa-api/actions/runs/7683885722/job/20939747455


